### PR TITLE
Code Cleanup

### DIFF
--- a/src/manage_cyhy_ops/cli.py
+++ b/src/manage_cyhy_ops/cli.py
@@ -125,8 +125,8 @@ def main() -> int:
         managers: List[ManageOperators] = []
         for region in regions:
             managers.append(ManageOperators(region, cyhy_ops, ssh_prefix))
-    except Exception as e:
-        logging.error(e)
+    except Exception as err:
+        logging.error(err)
         return 1
 
     username = validated_args["USERNAME"]

--- a/src/manage_cyhy_ops/cli.py
+++ b/src/manage_cyhy_ops/cli.py
@@ -83,8 +83,7 @@ def main() -> int:
             "--regions": And(
                 str,
                 lambda s: False
-                if False in map(lambda e: e in ALLOWED_REGIONS, s.split(","))
-                else True,
+                not in map(lambda r: r in ALLOWED_REGIONS, s.split(",")),
                 error=f"Invalid region(s) provided. Valid regions are: {ALLOWED_REGIONS}",
             ),
             "--ssm-ssh-prefix": SSM_KEY_VALIDATE,
@@ -164,5 +163,5 @@ def main() -> int:
     # guaranteed in the future. This handles any non-successful error code.
     if True in map(lambda e: e != 0, results):
         return 1
-    else:
-        return 0
+
+    return 0

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -80,7 +80,7 @@ class ManageOperators:
         try:
             # The SSM response on success currently only contains a version
             # number and the parameter tier.
-            # Neither are useful to us at this time, so we don't store them..
+            # Neither are useful to us at this time, so we don't store them.
             self._client.put_parameter(
                 Name=self.cyhy_ops_key,
                 Value=updated_users,
@@ -106,7 +106,7 @@ class ManageOperators:
         try:
             # The SSM response on success currently only contains a version
             # number and the parameter tier.
-            # Neither are useful to us at this time, so we don't store them..
+            # Neither are useful to us at this time, so we don't store them.
             logging.debug(
                 'Adding SSH key to Parameter Store in "%s" with key "%s/%s".',
                 self.region,

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -23,9 +23,9 @@ class ManageOperators:
         self.region = region
         try:
             self._client = boto3.client("ssm", region_name=region)
-        except ClientError as e:
+        except ClientError as err:
             logging.error('Unable to setup SSM client in region "%s".', region)
-            raise e
+            raise err
 
     def _get_cyhy_ops_list(self) -> List[str]:
         users: List[str] = []
@@ -40,8 +40,8 @@ class ManageOperators:
                 self.cyhy_ops_key,
                 self.region,
             )
-        except ClientError as e:
-            logging.error(e)
+        except ClientError as err:
+            logging.error(err)
 
         return users
 
@@ -89,13 +89,13 @@ class ManageOperators:
             )
             log_msg = f'Successfully {update_msg} CyHy Operators in region "%s"'
             logging.info(log_msg, username, self.region)
-        except ClientError as e:
+        except ClientError as err:
             logging.error(
                 'Unable to update parameter "%s" in region "%s".',
                 self.cyhy_ops_key,
                 self.region,
             )
-            logging.error(e)
+            logging.error(err)
             return 1
 
         return 0
@@ -133,8 +133,8 @@ class ManageOperators:
             logging.warning(
                 'If you need to overwrite this value, please use the "--overwrite" switch.'
             )
-        except ClientError as e:
-            logging.error(e)
+        except ClientError as err:
+            logging.error(err)
             return 1
 
         return self._update_cyhy_ops_users(username)
@@ -158,8 +158,8 @@ class ManageOperators:
                     username,
                     self.region,
                 )
-            except ClientError as e:
-                logging.error(e)
+            except ClientError as err:
+                logging.error(err)
                 return 1
 
         return self._update_cyhy_ops_users(username, remove=True)
@@ -182,8 +182,8 @@ class ManageOperators:
                 username,
                 self.region,
             )
-        except ClientError as e:
-            logging.error(e)
+        except ClientError as err:
+            logging.error(err)
             return 1
 
         enabled_users: List[str] = self._get_cyhy_ops_list()

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -100,8 +100,6 @@ class ManageOperators:
 
     def add_user(self, username: str, ssh_key: str, overwrite: bool = False) -> int:
         """Add an Operator to the Parameter Store."""
-        return_value = 0
-
         # Should this be atomic?
         try:
             # The SSM response on success currently only contains a version
@@ -134,16 +132,10 @@ class ManageOperators:
             logging.error(e)
             return 1
 
-        ret = self._update_cyhy_ops_users(username)
-        if ret:
-            return_value = ret
-
-        return return_value
+        return self._update_cyhy_ops_users(username)
 
     def remove_user(self, username: str, full: bool = False) -> int:
         """Remove an Operator from the Parameter Store."""
-        return_value = 0
-
         # Should this be atomic?
         if full:
             try:
@@ -163,11 +155,7 @@ class ManageOperators:
                 logging.error(e)
                 return 1
 
-        ret = self._update_cyhy_ops_users(username, remove=True)
-        if ret:
-            return_value = ret
-
-        return return_value
+        return self._update_cyhy_ops_users(username, remove=True)
 
     def check_user(self, username: str) -> int:
         """Check for the existence of an Operator and return information."""

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -70,7 +70,7 @@ class ManageOperators:
                 users.append(username)
                 update_msg = f'added "{username}" to'
 
-        updated_users = ",".join(users)
+        updated_users = ",".join(sorted(users))
 
         logging.debug(f'New CyHy Operators value: "{updated_users}".')
 

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -27,7 +27,7 @@ class ManageOperators:
             logging.error(f'Unable to setup SSM client in region "{region}".')
             raise e
 
-    def _get_cyhy_ops_list(self):
+    def _get_cyhy_ops_list(self) -> List[str]:
         users: List[str] = []
         try:
             response = self._client.get_parameter(
@@ -155,7 +155,7 @@ class ManageOperators:
 
         return return_value
 
-    def remove_user(self, username: str, full: bool = False):
+    def remove_user(self, username: str, full: bool = False) -> int:
         """Remove an Operator from the Parameter Store."""
         return_value = 0
 

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -47,6 +47,7 @@ class ManageOperators:
     def _update_cyhy_ops_users(self, username: str, remove: bool = False) -> int:
         """Update the list of CyHy Operators to use when an instance is built."""
         users: List[str] = self._get_cyhy_ops_list()
+        update_msg: str = "performed no operations on"
 
         logging.debug("Current CyHy Operators: {users}.")
 

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -70,47 +70,32 @@ class ManageOperators:
                 users.append(username)
                 update_msg = f'added "{username}" to'
 
-        if len(users) == 0:
-            try:
-                logging.warning(
-                    "No CyHy Operators left, deleting CyHy Operators parameter "
-                    f'from region "{self.region}".'
-                )
-                # Response is an empty dictionary on success.
-                self._client.delete_parameter(Name=self.cyhy_ops_key)
-            except ClientError as e:
-                logging.error(
-                    "Unable to delete the CyHy Operators parameter in "
-                    f'region "{self.region}".'
-                )
-                logging.error(e)
-                return 1
-        else:
-            updated_users = ",".join(users)
+        updated_users = ",".join(users)
 
-            logging.debug(f'New CyHy Operators value: "{updated_users}".')
+        logging.debug(f'New CyHy Operators value: "{updated_users}".')
 
-            try:
-                # The SSM response on success currently only contains a version
-                # number and the parameter tier.
-                # Neither are useful to us at this time, so we don't store them..
-                self._client.put_parameter(
-                    Name=self.cyhy_ops_key,
-                    Value=updated_users,
-                    Type="SecureString",
-                    Overwrite=True,
-                )
-                logging.info(
-                    f"Successfully {update_msg} CyHy Operators in region "
-                    f'"{self.region}".'
-                )
-            except ClientError as e:
-                logging.error(
-                    f'Unable to update parameter "{self.cyhy_ops_key}" '
-                    f'in region "{self.region}".'
-                )
-                logging.error(e)
-                return 1
+        try:
+            # The SSM response on success currently only contains a version
+            # number and the parameter tier.
+            # Neither are useful to us at this time, so we don't store them..
+            self._client.put_parameter(
+                Name=self.cyhy_ops_key,
+                Value=updated_users,
+                Type="SecureString",
+                Overwrite=True,
+            )
+            logging.info(
+                f"Successfully {update_msg} CyHy Operators in region "
+                f'"{self.region}".'
+            )
+        except ClientError as e:
+            logging.error(
+                f'Unable to update parameter "{self.cyhy_ops_key}" '
+                f'in region "{self.region}".'
+            )
+            logging.error(e)
+            return 1
+
         return 0
 
     def add_user(self, username: str, ssh_key: str, overwrite: bool = False) -> int:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR is mostly just some housekeeping for this project. There is a bug fixed in 93798d3, and a potential side-effect is removed in 28c9247, but the bulk is some general polish. The logging has also been adjusted to `printf` style that is preferred because of `logging` library internals.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The bug I mentioned is a problem for anyone else trying to use this code in production. While I was fixing the aforementioned bug, I wanted to do some general housekeeping since this project was created before we moved to an "Initial Pull Request" model as talked about in the [development guide](https://github.com/cisagov/development-guide/tree/develop/project_setup#create-an-initial-pull-request).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes and some basic checks I ran locally gave expected results.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
