### PR TITLE
Fix Logging in ManageOperators Class

### DIFF
--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -120,7 +120,7 @@ class ManageOperators:
                 Overwrite=overwrite,
             )
             logging.info(
-                'Successfully added "%s"\'s SSH key to the Parameter Store in "%s".',
+                'Added "%s"\'s SSH key to the Parameter Store in "%s".',
                 username,
                 self.region,
             )
@@ -148,7 +148,7 @@ class ManageOperators:
                 # Response is an empty dictionary on success.
                 self._client.delete_parameter(Name=parameter_name)
                 logging.info(
-                    'Successfully removed SSH key for user "%s" in region "%s".',
+                    'Removed SSH key for user "%s" in region "%s".',
                     username,
                     self.region,
                 )

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -108,10 +108,10 @@ class ManageOperators:
             # number and the parameter tier.
             # Neither are useful to us at this time, so we don't store them.
             logging.debug(
-                'Adding SSH key to Parameter Store in "%s" with key "%s/%s".',
-                self.region,
+                'Adding SSH key "%s/%s" to the Parameter Store in region "%s".',
                 self.ssh_key_prefix,
                 username,
+                self.region,
             )
             self._client.put_parameter(
                 Name=f"{self.ssh_key_prefix}/{username}",
@@ -126,7 +126,7 @@ class ManageOperators:
             )
         except self._client.exceptions.ParameterAlreadyExists:
             logging.warning(
-                'SSH key for "%s" already exists in the Parameter Store for region "%s".',
+                'SSH key for "%s" already exists in the Parameter Store in region "%s".',
                 username,
                 self.region,
             )
@@ -148,13 +148,13 @@ class ManageOperators:
                 # Response is an empty dictionary on success.
                 self._client.delete_parameter(Name=parameter_name)
                 logging.info(
-                    'Removed SSH key for user "%s" in region "%s".',
+                    'Removed SSH key for "%s" from the Parameter Store in region "%s".',
                     username,
                     self.region,
                 )
             except self._client.exceptions.ParameterNotFound:
                 logging.warning(
-                    'User "%s" does not have an SSH key stored in  the Parameter Store of region "%s".',
+                    'SSH key for "%s" does not exist in the Parameter Store in region "%s".',
                     username,
                     self.region,
                 )

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -48,7 +48,7 @@ class ManageOperators:
     def _update_cyhy_ops_users(self, username: str, remove: bool = False) -> int:
         """Update the list of CyHy Operators to use when an instance is built."""
         users: List[str] = self._get_cyhy_ops_list()
-        update_msg: str = "performed no operations on"
+        update_msg: str = 'Performed no operations for "%s"'
 
         logging.debug("Current CyHy Operators: %s.", users)
 
@@ -61,7 +61,7 @@ class ManageOperators:
                 )
             else:
                 users.remove(username)
-                update_msg = 'removed "%s" from'
+                update_msg = 'Removed "%s" from Cyhy Operators'
         else:
             if username in users:
                 logging.warning(
@@ -71,7 +71,7 @@ class ManageOperators:
                 )
             else:
                 users.append(username)
-                update_msg = 'added "%s" to'
+                update_msg = 'Added "%s" to Cyhy Operators'
 
         updated_users = ",".join(sorted(users))
 
@@ -87,7 +87,7 @@ class ManageOperators:
                 Type="SecureString",
                 Overwrite=True,
             )
-            log_msg = f'Successfully {update_msg} CyHy Operators in region "%s"'
+            log_msg = f'{update_msg} in region "%s"'
             logging.info(log_msg, username, self.region)
         except ClientError as err:
             logging.error(

--- a/src/manage_cyhy_ops/manageoperators.py
+++ b/src/manage_cyhy_ops/manageoperators.py
@@ -87,7 +87,7 @@ class ManageOperators:
                 Type="SecureString",
                 Overwrite=True,
             )
-            log_msg = f'{update_msg} in region "%s"'
+            log_msg = f'{update_msg} in region "%s".'
             logging.info(log_msg, username, self.region)
         except ClientError as err:
             logging.error(


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes an issue with a logging message and makes some small edits to improve readability and consistency.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I was testing a bash script that uses this today and when using the `add` command twice ran into an error with logging output:

```log
--- Logging error ---
Traceback (most recent call last):
  File "/Users/mcdonnnj/.pyenv/versions/3.9.1/lib/python3.9/logging/__init__.py", line 1079, in emit
    msg = self.format(record)
  File "/Users/mcdonnnj/.pyenv/versions/3.9.1/lib/python3.9/logging/__init__.py", line 923, in format
    return fmt.format(record)
  File "/Users/mcdonnnj/.pyenv/versions/3.9.1/lib/python3.9/logging/__init__.py", line 659, in format
    record.message = record.getMessage()
  File "/Users/mcdonnnj/.pyenv/versions/3.9.1/lib/python3.9/logging/__init__.py", line 363, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/mcdonnnj/.pyenv/versions/manage-cyhy-ops/bin/manage-cyhy-ops", line 33, in <module>
    sys.exit(load_entry_point('manage-cyhy-ops', 'console_scripts', 'manage-cyhy-ops')())
  File "/Volumes/workspace/my-repos/manage-cyhy-ops/src/manage_cyhy_ops/cli.py", line 151, in main
    manager.add_user(username, ssh_key, overwrite=overwrite_ssh_key)
  File "/Volumes/workspace/my-repos/manage-cyhy-ops/src/manage_cyhy_ops/manageoperators.py", line 140, in add_user
    return self._update_cyhy_ops_users(username)
  File "/Volumes/workspace/my-repos/manage-cyhy-ops/src/manage_cyhy_ops/manageoperators.py", line 91, in _update_cyhy_ops_users
    logging.info(log_msg, username, self.region)
Message: 'Successfully performed no operations on CyHy Operators in region "%s"'
Arguments: ('first.last', 'us-east-1')
```

While fixing that issue I improved the output phrasing and made changes to keep all the logging consistent as a result.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes. I verified that the modified version does not exhibit the error mentioned above.

```log
WARNING SSH key for "first.last" already exists in the Parameter Store for region "us-east-1".
WARNING If you need to overwrite this value, please use the "--overwrite" switch.
WARNING User "first.last" is already in the list of active CyHy Operators in region "us-east-1".
INFO Performed no operations for "first.last" in region "us-east-1"
```
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
